### PR TITLE
read-project twice to resolve `:exoscale.project/file`

### DIFF
--- a/src/exoscale/tools/project.clj
+++ b/src/exoscale/tools/project.clj
@@ -56,8 +56,10 @@
     (assoc :exoscale.project/version (slurp version-file))))
 
 (defn into-opts [opts]
-  (let [opts (-> default-opts
-                 (merge (read-project (into default-opts opts)) opts)
+  (let [project-from-deps-edn (read-project (into default-opts opts))
+        project (read-project project-from-deps-edn)
+        opts (-> default-opts
+                 (merge project-from-deps-edn project opts)
                  assoc-version)]
     (when-not (s/valid? :exoscale.project/opts opts)
       (let [msg (format "Invalid exoscale.project configuration in %s"


### PR DESCRIPTION
When specifying an alternate project file, the exoscale.project map needs to be read again, in order to resolve project data specified in `:exoscale.project/file` in deps.edn.