### PR TITLE
Allow forwarding options to tools.build.api/uber

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ We suggest you add the following aliases to your bash profile, all these plugins
 should be available from any module.
 
 ``` bash
-## common exoscsale tools deps aliases
+## common exoscale tools deps aliases
 alias clj-test/repl='clj -A:test'
 alias clj-test/unit='clj -X:test:test/unit'
 alias clj-test/integration='clj -X:test:test/integration'

--- a/src/exoscale/tools/project/api/jar.clj
+++ b/src/exoscale/tools/project/api/jar.clj
@@ -47,7 +47,7 @@
 (defn uberjar
   [opts]
   (let [{:exoscale.project/keys [_env lib _version _version-file main
-                                 src-dirs class-dir basis uberjar-file deps-file]
+                                 src-dirs class-dir basis uberjar-file uber-opts deps-file]
          :as opts} opts
         _ (api/clean opts)
         version (v/get-version opts)
@@ -65,11 +65,13 @@
                     :class-dir class-dir
                     :src-dirs src-dirs})
     (println "Creating uberjar: " uber-file)
-    (b/uber {:basis basis
-             :class-dir class-dir
-             :main main
-             :uber-file uber-file})
+    (b/uber (merge uber-opts {:basis basis
+                              :class-dir class-dir
+                              :main main
+                              :uber-file uber-file}))
+                   
     (into opts
           #:exoscale.project{:basis basis
                              :version version
-                             :uberjar-file uber-file})))
+                             :uberjar-file uber-file
+                             :uber-opts uber-opts})))


### PR DESCRIPTION
[clojure.tools.build.api/uber](https://clojure.github.io/tools.build/clojure.tools.build.api.html#var-uber) accepts options like `:exclude` and`:conflict-handlers` that can be useful to fix conflicts that can arise when building uberjar on some projects.

As an example, I had this error building uberjar:
```
 ~/e/p/backend-metering || jeremyvdw/tools.project => clj -T:project uberjar
Copying src-dirs
(...)
Creating uberjar:  /Users/jeremyvandewyngaert/exoscale/private/backend-metering/target/backend-metering-0.1.283-SNAPSHOT-standalone.jar
Execution error (ExceptionInfo) at clojure.tools.build.tasks.uber/explode (uber.clj:168).
Cannot write META-INF/license/LICENSE.base64.txt from io.netty/netty as parent dir is a file from another lib. One of them must be excluded.
```

This allows to set some `uber-opts`, that will be forwarded to tools.builds' `uber` fn; like `:exoscale.project/uber-opts {:exclude ["^META-INF/license/.*"]}}`.