### PR TITLE
add a `self-prep` task to run before building jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A convenience `Makefile` is provided with projects bootstrapped with
 - [merge-aliases](doc/target/merge-aliases.md): managed alias management
 - [outdated](doc/target/outdated.md): outdated version check
 - [prep](doc/target/prep.md): handle prep libs
+- [prep-self](doc/target/prep-self.md): handle prep task for the current project
 - [release](doc/target/release.md): project release
 - [task](doc/target/task.md): arbitrary task run
 - [test](doc/target/test.md): run tests

--- a/doc/target/prep-self.md
+++ b/doc/target/prep-self.md
@@ -1,0 +1,22 @@
+## `prep-self` target
+
+Run the [prep task](https://clojure.org/guides/deps_and_cli#prep_libs) of the current
+project where applicable.
+To avoid unnecessarily running in all sub modules, predicated
+on `:deps/prep-lib` in the deps edn file.
+
+This is implicitly ran for `check`, `jar`, and `uberjar` and thus is only useful
+as a debugging facility.
+
+### Usage
+
+```bash
+clojure -T:project prep-self
+```
+
+### Multi-module project behavior
+
+When a `:exoscale.project/modules` key is present in the project's
+configuration, runs through all configured module to call the
+`prep-self` target instead of running on the project, only accounting
+for those having `:deps/prep-lib` set to true.

--- a/doc/target/prep.md
+++ b/doc/target/prep.md
@@ -4,6 +4,9 @@ Run the [prep task](https://clojure.org/guides/deps_and_cli#prep_libs) of depend
 To avoid unnecessarily running in all sub modules, predicated
 on `:exoscale.project/needs-prep?` in the deps edn file.
 
+This is implicitly ran for `check`, `jar`, and `uberjar` and thus is only useful
+as a debugging facility.
+
 ### Usage
 
 ```bash

--- a/src/exoscale/tools/project.clj
+++ b/src/exoscale/tools/project.clj
@@ -88,6 +88,10 @@
   [opts]
   (task-or-tool opts :revision-sha ps/revision-sha))
 
+(defn prep-self
+  [opts]
+  (task-or-tool opts :prep-self ps/prep-self))
+
 (def task
   ps/task)
 

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -87,7 +87,11 @@
              {:run :exoscale.tools.project.standalone/git-tag-version}
              {:run :exoscale.tools.project.standalone/version-bump-and-snapshot}
              {:run :exoscale.tools.project.standalone/git-commit-version}
-             {:run :exoscale.tools.project.standalone/git-push}]})
+             {:run :exoscale.tools.project.standalone/git-push}]
+
+   :prep-self [{:run :exoscale.tools.project.standalone/prep-self
+                :for-all [:exoscale.project/modules]
+                :when :deps/prep-lib}]})
 
 (defn shell*
   [cmds {::keys [dir env]}]


### PR DESCRIPTION
prep only takes care of prepping dependencies not the project
itself, which is required before building jars that need to
contain compiled classes for instance