### PR TITLE
small prn fix + deploy task changes

### DIFF
--- a/doc/target/deploy.md
+++ b/doc/target/deploy.md
@@ -11,7 +11,7 @@ clojure -T:project deploy
 
 ### Additional project configuration
 
-- `:exoscale.project/remote-deploy?`: Remote deploys are not attempted when set to `false`. Defaults to `true
+- `:exoscale.project/deploy?`: must be set to true for a deploy task to target a module or the root
 - `:slipset.deps-deploy/exec-args`: Exec arguments for [deps-deploy](https://github.com/slipset/deps-deploy).
 
 Note that by default if pushing to object storage, an Exoscale SOS bucket is assumed.

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -46,7 +46,6 @@
               :for-all [:exoscale.project/modules]}]
 
    :deploy [{:run :exoscale.tools.project.standalone/deploy
-             :unless :exoscale.project/prevent-deploy? ; legacy
              :when :exoscale.project/deploy?
              :for-all [:exoscale.project/modules]}]
 

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -131,9 +131,12 @@
 
 (defn- filter-dir?
   [task sub-edn]
-  (let [when' (get sub-edn (:when task) true)
+  (let [when' (if-let [when-k (:when task)]
+                (get sub-edn when-k)
+                true)
         unless' (get sub-edn (:unless task))]
-    (and (not unless') when')))
+    (and (not unless')
+         when')))
 
 (defn- relevant-dir?
   [task dir]

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -173,7 +173,10 @@
       (println (format "Task '%s' not found" id))
       (System/exit 1))
 
-    (println "starting task:" task-id "for:" lib)
+    (println "starting task:" task-id
+             (if lib
+               (str "for:" lib)
+               "from `root`"))
     (flush)
 
     (doseq [{:as task :keys [for-all]} task-def

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -46,7 +46,8 @@
               :for-all [:exoscale.project/modules]}]
 
    :deploy [{:run :exoscale.tools.project.standalone/deploy
-             :unless :exoscale.project/prevent-deploy?
+             :unless :exoscale.project/prevent-deploy? ; legacy
+             :when :exoscale.project/deploy?
              :for-all [:exoscale.project/modules]}]
 
    :jar [{:run :exoscale.tools.project.standalone/jar

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -84,7 +84,6 @@
 
    :release [{:run :exoscale.tools.project.standalone/version-remove-snapshot}
              {:ref :deploy}
-             {:ref :uberjar}
              {:run :exoscale.tools.project.standalone/git-commit-version}
              {:run :exoscale.tools.project.standalone/git-tag-version}
              {:run :exoscale.tools.project.standalone/version-bump-and-snapshot}


### PR DESCRIPTION
* printing fix

shows
> starting task: :uberjar from `root`

instead of
> starting task: :uberjar from nil

* deploy task changes: 
:prevent-deploy? and :remote-deploy? are removed in favor or explicit
:exoscale.project/deploy?

* remove uberjar from deploy task
