### PR TITLE
clj: forward java opts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,18 @@
+# Testing against a specific branch
+
+To test this project within the context of another project, either use a different sha, or point to 
+this library via local coordinates:
+
+```clojure
+{:extra-deps {io.github.exoscale/tools.project {:git/sha "my-branch-complete-sha"}}}
+             
+;; or
+{:extra-deps {io.github.exoscale/tools.project {:local/root "../tools.project"}}}
+```
+
+Then you can run & optionally debug the process:
+
+```shell
+clj -J-Xdebug -J-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 -T:project test :kaocha.filter/focus '[:integration]'
+;; connect remote debugger on port 5005
+```

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -155,7 +155,7 @@
                        (conj (pr-str v))))
                  ["clojure" "-J-Dclojure.main.report=stderr" "-X:test"]
                  (dissoc opts :exoscale.tools.project.api.tasks/dir))]
-    (pio/shell [cmdline] {:dir dir #_#_:env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}}))
+    (pio/shell [cmdline] {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}}))
   opts)
 
 (defn version

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -67,7 +67,7 @@
     :or {dir "."}
     :as opts}]
   (println "running prep task for dependencies in:" lib)
-  (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-X:deps" "prep" ":log" "debug"]] {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
+  (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-X:deps" "prep" ":log" "debug"]] {:dir dir #_#_:env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
   opts)
 
 (defn prep-self
@@ -142,7 +142,7 @@
         source-dirs (find-source-dirs opts)]
     (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-Sdeps" (pr-str deps-check-config) "-X:spootnik-deps-check:test"
                  "spootnik.deps-check/check" ":paths" (pr-str source-dirs)]]
-               {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
+               {:dir dir #_#_:env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
     opts))
 
 (defn test
@@ -155,7 +155,7 @@
                        (conj (pr-str v))))
                  ["clojure" "-J-Dclojure.main.report=stderr" "-X:test"]
                  (dissoc opts :exoscale.tools.project.api.tasks/dir))]
-    (pio/shell [cmdline] {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}}))
+    (pio/shell [cmdline] {:dir dir #_#_:env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}}))
   opts)
 
 (defn version

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -67,7 +67,7 @@
     :or {dir "."}
     :as opts}]
   (println "running prep task for dependencies in:" lib)
-  (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-X:deps" "prep" ":log" "debug"]] {:dir dir #_#_:env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
+  (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-X:deps" "prep" ":log" "debug"]] {:dir dir})
   opts)
 
 (defn prep-self
@@ -142,7 +142,7 @@
         source-dirs (find-source-dirs opts)]
     (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-Sdeps" (pr-str deps-check-config) "-X:spootnik-deps-check:test"
                  "spootnik.deps-check/check" ":paths" (pr-str source-dirs)]]
-               {:dir dir #_#_:env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
+               {:dir dir})
     opts))
 
 (defn test
@@ -153,9 +153,9 @@
                    (-> cmdline
                        (conj (pr-str k))
                        (conj (pr-str v))))
-                 ["clojure" "-J-Dclojure.main.report=stderr" "-X:test"]
+                 ["clojure" "-J--enable-preview" "-J-Dclojure.main.report=stderr" "-X:test"]
                  (dissoc opts :exoscale.tools.project.api.tasks/dir))]
-    (pio/shell [cmdline] {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}}))
+    (pio/shell [cmdline] {:dir dir}))
   opts)
 
 (defn version

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -148,12 +148,15 @@
 (defn test
   [opts]
   (let [dir (or (:exoscale.tools.project.api.tasks/dir opts) ".")
+        edn (:exoscale.tools.project.api.tasks/task-deps-edn opts)
+        jvm-flags (->> (get-in edn [:aliases :test :jvm-opts])
+                       (mapv #(str "-J" %)))
         cmdline (reduce-kv
                  (fn [cmdline k v]
                    (-> cmdline
                        (conj (pr-str k))
                        (conj (pr-str v))))
-                 ["clojure" "-J--enable-preview" "-J-Dclojure.main.report=stderr" "-X:test"]
+                 (reduce into ["clojure"]  (vector jvm-flags ["-J-Dclojure.main.report=stderr" "-X:test"]))
                  (dissoc opts :exoscale.tools.project.api.tasks/dir))]
     (pio/shell [cmdline] {:dir dir}))
   opts)

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -67,7 +67,7 @@
     :or {dir "."}
     :as opts}]
   (println "running prep task for dependencies in:" lib)
-  (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-X:deps" "prep" ":log" "debug"]] {:dir dir})
+  (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-X:deps" "prep" ":log" "debug"]] {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
   opts)
 
 (defn prep-self
@@ -142,13 +142,12 @@
         source-dirs (find-source-dirs opts)]
     (pio/shell [["clojure" "-J-Dclojure.main.report=stderr" "-Sdeps" (pr-str deps-check-config) "-X:spootnik-deps-check:test"
                  "spootnik.deps-check/check" ":paths" (pr-str source-dirs)]]
-               {:dir dir})
+               {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}})
     opts))
 
 (defn test
   [opts]
   (let [dir (or (:exoscale.tools.project.api.tasks/dir opts) ".")
-        _ (println opts)
         cmdline (reduce-kv
                  (fn [cmdline k v]
                    (-> cmdline
@@ -156,7 +155,7 @@
                        (conj (pr-str v))))
                  ["clojure" "-J-Dclojure.main.report=stderr" "-X:test"]
                  (dissoc opts :exoscale.tools.project.api.tasks/dir))]
-    (pio/shell [cmdline] {:dir dir}))
+    (pio/shell [cmdline] {:dir dir :env {"JAVA_OPTS" (System/getenv "JAVA_OPTS")}}))
   opts)
 
 (defn version

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -148,6 +148,7 @@
 (defn test
   [opts]
   (let [dir (or (:exoscale.tools.project.api.tasks/dir opts) ".")
+        _ (println opts)
         cmdline (reduce-kv
                  (fn [cmdline k v]
                    (-> cmdline

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -129,10 +129,11 @@
 (defn- run-task!
   [{:as task :keys [shell ref run args]}
    {::keys [dir] :as opts}]
-  (let [ret (s/conform :exoscale.project/task task)]
+  (let [ret (s/conform :exoscale.project/task task)
+        metadata (meta task)]
     (case (first ret)
       :shell (shell* shell opts)
-      :run (run* run (merge {} args opts))
+      :run (run* run (merge metadata args opts))
       :ref (binding [td/*the-dir* dir]
              (exoscale.tools.project.api.tasks/task (assoc opts :id ref) opts)))))
 


### PR DESCRIPTION
~This is really a hack, since the expectation is that eg: `test` aliases key `:jvm-args` are passed when running tests.
Since the test is via kaocha and is shelled out, the `jvm-args` vector is not passed down, hence we do this short term hack of passing JVM_OPTS to the `pio/shell` in the hopes that it will be picked up by whatever process is being spawn.~

Previous paragraph didn't work, I ended up appending the `:jvm-opts` from the `test` alias.
Presumable, other situations where we shell out suffer the same issue.

The current use case is to run tests that use virtual threads, and require the `--enable-preview` JDK flag.