### PR TITLE
adds a resources/VERSION file on `check` and `uberjar` tasks

### DIFF
--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -46,6 +46,16 @@
     (println "storing git sha in" git-version-file)
     opts))
 
+(defn revision-version
+  [opts]
+  (let [{:exoscale.tools.project.api.tasks/keys [dir]} opts
+        version (:exoscale.project/version opts)
+        version-file (str (fs/path dir "resources" "VERSION"))]
+    (fs/create-dirs (fs/path dir "resources"))
+    (spit version-file version)
+    (println "storing version in" version-file)
+    opts))
+
 (defn info
   [opts]
   (let [{:exoscale.project/keys [extra-deps-files version modules lib]} opts]

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -179,10 +179,10 @@
   (comp api/revision-sha into-opts))
 
 (def ^{:arglists '([opts])} check
-  (comp api/check api/revision-sha api/prep-self api/prep into-opts))
+  (comp api/check api/revision-version api/revision-sha api/prep-self api/prep into-opts))
 
 (def ^{:arglists '([opts])} uberjar
-  (comp jar/uberjar api/revision-sha api/prep-self api/prep api/clean into-opts))
+  (comp jar/uberjar api/revision-version api/revision-sha api/prep-self api/prep api/clean into-opts))
 
 (def ^{:arglists '([opts])} test
   api/test)


### PR DESCRIPTION
In order to get the semver at hand, write a resources/VERSION file in jar file.