### PR TITLE
Fix version file in build

### DIFF
--- a/doc/target/uberjar.md
+++ b/doc/target/uberjar.md
@@ -17,4 +17,6 @@ clojure -T:project uberjar
 
 When a `:exoscale.project/modules` key is present in the project's
 configuration, runs through all configured module to call the
-`uberjar` target instead of running on the project.
+`uberjar` target instead of running on the project.  
+Additionally, a `resources/VERSION` file is added to the uberjar, containing
+the specified project's version.

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -10,6 +10,7 @@
             [antq.core :as antq]
             [exoscale.tools.project.dir :as dir]
             [exoscale.tools.project.api.git :as git]
+            [exoscale.tools.project.api.version :as version]
             [exoscale.tools.project.io :as pio]))
 
 (defn- find-source-dirs
@@ -49,7 +50,7 @@
 (defn revision-version
   [opts]
   (let [{:exoscale.tools.project.api.tasks/keys [dir]} opts
-        version (:exoscale.project/version opts)
+        version (version/get-version opts)
         version-file (str (fs/path dir "resources" "VERSION"))]
     (fs/create-dirs (fs/path dir "resources"))
     (spit version-file version)


### PR DESCRIPTION
Make `api/revision-version` to look for version in version-file if specified.
Added reference to `resources/VERSION` in uberjar file