### PR TITLE
shell: exit only when `fatal?` is true

### DIFF
--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -47,7 +47,7 @@
       (fs/create-dirs (fs/path dir "resources"))
       (spit git-version-file revision-sha)
       (println "storing git sha in" git-version-file))
-    (catch Throwable e
+    (catch Exception e
       (println (format "failed to retrieve git version %s" (ex-message e)))))
   opts)
 

--- a/src/exoscale/tools/project/api.clj
+++ b/src/exoscale/tools/project/api.clj
@@ -46,10 +46,10 @@
           git-version-file (str (fs/path dir "resources" "git-version"))]
       (fs/create-dirs (fs/path dir "resources"))
       (spit git-version-file revision-sha)
-      (println "storing git sha in" git-version-file)
-      opts)
-    (catch Exception e
-      (println (format "failed to retrieve git version %s" (ex-message e))))))
+      (println "storing git sha in" git-version-file))
+    (catch Throwable e
+      (println (format "failed to retrieve git version %s" (ex-message e)))))
+  opts)
 
 (defn revision-version
   [opts]

--- a/src/exoscale/tools/project/api/git.clj
+++ b/src/exoscale/tools/project/api/git.clj
@@ -25,6 +25,9 @@
 
 (defn revision-sha
   [_]
-  (-> (pio/shell ["git rev-parse HEAD"] {:dir td/*the-dir* :out :capture})
+  (-> (pio/shell ["git rev-parse HEAD"]
+                 {:dir td/*the-dir*
+                  :out :capture
+                  :fatal? false})
       :out
       str/trim-newline))

--- a/src/exoscale/tools/project/io.clj
+++ b/src/exoscale/tools/project/io.clj
@@ -9,7 +9,7 @@
 
 (defn shell
   "Run shell commands contained in `cmds`. The first unsuccesful exit triggers a system exit."
-  [cmds {:keys [dir env out]}]
+  [cmds {:keys [dir env out fatal?] :or {fatal? true}}]
   (try
     (last
      (for [cmd cmds]
@@ -20,4 +20,5 @@
            (check))))
     (catch Exception _
       ;; At this stage we already printed the relevant error to stdout
-      (System/exit 1))))
+      (when (true? fatal?)
+        (System/exit 1)))))


### PR DESCRIPTION
There is some shell operations (like the one done in `git/revision-sha`) that should not be terminal/fatal.
We are adding a flag to define how to handle exception in `io/shell` and are leveraging it to prevent `git/revision-sha` to be terminal when git is not present