### PR TITLE
version-fn versioning support (adds git-rev-count and epoch versioning)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -7,14 +7,12 @@
                                             exoscale.tools.project.module/install
                                             exoscale.tools.project.module/jar
                                             exoscale.tools.project.module/release
-                                            exoscale.tools.project.module/release-git-count-revs
                                             exoscale.tools.project.module/task
                                             exoscale.tools.project.module/uberjar
                                             exoscale.tools.project.standalone/git-commit-version
                                             exoscale.tools.project.standalone/git-push
                                             exoscale.tools.project.standalone/git-tag-version
                                             exoscale.tools.project.standalone/release
-                                            exoscale.tools.project.standalone/release-git-count-revs
                                             exoscale.tools.project.standalone/version-bump-and-snapshot
                                             exoscale.tools.project.standalone/version-remove-snapshot
                                             exoscale.tools.project.template/data-fn

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -14,6 +14,7 @@
                                             exoscale.tools.project.standalone/git-push
                                             exoscale.tools.project.standalone/git-tag-version
                                             exoscale.tools.project.standalone/release
+                                            exoscale.tools.project.standalone/release-git-count-revs
                                             exoscale.tools.project.standalone/version-bump-and-snapshot
                                             exoscale.tools.project.standalone/version-remove-snapshot
                                             exoscale.tools.project.template/data-fn

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,25 @@
 {:linters
- {:clojure-lsp/unused-public-var {:exclude [exoscale.tools.project/add-module
+ {:clojure-lsp/unused-public-var {:exclude [exoscale.tools.project.api.java/compile
+                                            exoscale.tools.project.api/version
+                                            exoscale.tools.project.module/clean
+                                            exoscale.tools.project.module/compile
+                                            exoscale.tools.project.module/deploy
+                                            exoscale.tools.project.module/install
+                                            exoscale.tools.project.module/jar
+                                            exoscale.tools.project.module/release
+                                            exoscale.tools.project.module/release-git-count-revs
+                                            exoscale.tools.project.module/task
+                                            exoscale.tools.project.module/uberjar
+                                            exoscale.tools.project.standalone/git-commit-version
+                                            exoscale.tools.project.standalone/git-push
+                                            exoscale.tools.project.standalone/git-tag-version
+                                            exoscale.tools.project.standalone/release
+                                            exoscale.tools.project.standalone/version-bump-and-snapshot
+                                            exoscale.tools.project.standalone/version-remove-snapshot
+                                            exoscale.tools.project.template/data-fn
+                                            exoscale.tools.project.template/module-data-fn
+                                            exoscale.tools.project.template/template-fn
+                                            exoscale.tools.project/add-module
                                             exoscale.tools.project/check
                                             exoscale.tools.project/clean
                                             exoscale.tools.project/deploy
@@ -25,25 +45,7 @@
                                             exoscale.tools.project/uberjar
                                             exoscale.tools.project/version
                                             exoscale.tools.project/version-bump-and-snapshot
-                                            exoscale.tools.project/version-remove-snapshot
-                                            exoscale.tools.project.api/version
-                                            exoscale.tools.project.api.java/compile
-                                            exoscale.tools.project.module/clean
-                                            exoscale.tools.project.module/compile
-                                            exoscale.tools.project.module/deploy
-                                            exoscale.tools.project.module/install
-                                            exoscale.tools.project.module/jar
-                                            exoscale.tools.project.module/release
-                                            exoscale.tools.project.module/task
-                                            exoscale.tools.project.module/uberjar
-                                            exoscale.tools.project.standalone/git-commit-version
-                                            exoscale.tools.project.standalone/git-push
-                                            exoscale.tools.project.standalone/git-tag-version
-                                            exoscale.tools.project.standalone/release
-                                            exoscale.tools.project.standalone/version-bump-and-snapshot
-                                            exoscale.tools.project.standalone/version-remove-snapshot
-                                            exoscale.tools.project.template/data-fn
-                                            exoscale.tools.project.template/module-data-fn
-                                            exoscale.tools.project.template/template-fn]}}
+                                            exoscale.tools.project/version-git-count-revs
+                                            exoscale.tools.project/version-remove-snapshot]}}
  :skip-comments true
  :output {:exclude-files ["^resources/exoscale"]}}

--- a/doc/target/release.md
+++ b/doc/target/release.md
@@ -4,7 +4,30 @@ Perform a release of the project. This is merely a [task](../task.md) run
 for the `:release/single` task in standalone projects, and for the `:release/modules`
 task in multi-module projects.
 
-### Usage
+### Usage release+tag task
+
+This is a simple release task that will release the artifact and not commit the
+version file (if any provided), and then git tag the release simply. That can be
+used with version-fn to create releases based on git-revs-count or timestamp
+schemes (see: `exoscale.tools.project.api.version/git-count-revs` &
+`exoscale.tools.project.api.version/epoch`).
+
+```bash
+clojure -T:project release+tag
+```
+
+The default release+tag task is:
+
+``` clojure
+[{:run :exoscale.tools.project.standalone/deploy}
+ {:run :exoscale.tools.project.standalone/git-tag-version}
+ {:run :exoscale.tools.project.standalone/git-push}]
+```
+
+
+### Usage release task
+
+This task will trigger the update of the VERSION file provided and commit it, then trigger a release
 
 ```bash
 clojure -T:project release
@@ -33,4 +56,5 @@ The default release task configuration is:
  {:run :exoscale.tools.project.standalone/version-bump-and-snapshot}
  {:run :exoscale.tools.project.standalone/git-commit-version}
  {:run :exoscale.tools.project.standalone/git-push}]
+
 ```

--- a/src/exoscale/tools/project.clj
+++ b/src/exoscale/tools/project.clj
@@ -87,9 +87,9 @@
   [opts]
   (task-or-tool opts :release/modules ps/release))
 
-(defn release-git-count-revs
+(defn release+tag
   [opts]
-  (task-or-tool opts :release-git-count-revs/modules ps/release-git-count-revs))
+  (task-or-tool opts :release+tag/modules ps/release+tag))
 
 (defn revision-sha
   [opts]

--- a/src/exoscale/tools/project.clj
+++ b/src/exoscale/tools/project.clj
@@ -87,6 +87,10 @@
   [opts]
   (task-or-tool opts :release/modules ps/release))
 
+(defn release-git-count-revs
+  [opts]
+  (task-or-tool opts :release/git-count-revs ps/release))
+
 (defn revision-sha
   [opts]
   (task-or-tool opts :revision-sha ps/revision-sha))

--- a/src/exoscale/tools/project.clj
+++ b/src/exoscale/tools/project.clj
@@ -89,7 +89,7 @@
 
 (defn release-git-count-revs
   [opts]
-  (task-or-tool opts :release/git-count-revs ps/release))
+  (task-or-tool opts :release-git-count-revs/modules ps/release-git-count-revs))
 
 (defn revision-sha
   [opts]

--- a/src/exoscale/tools/project/api/git.clj
+++ b/src/exoscale/tools/project/api/git.clj
@@ -1,7 +1,5 @@
 (ns exoscale.tools.project.api.git
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.tools.build.api :as b]
+  (:require [clojure.string :as str]
             [clojure.tools.deps.alpha.util.dir :as td]
             [exoscale.tools.project.api.version :as v]
             [exoscale.tools.project.io :as pio]))
@@ -33,10 +31,3 @@
                   :fatal? false})
       :out
       str/trim-newline))
-
-(defn git-count-revs
-  [{:as _opts :exoscale.project/keys [version-template-file]
-    :or {version-template-file "VERSION_TEMPLATE"}}]
-  (str/replace (slurp (td/canonicalize (io/file version-template-file)))
-               "GENERATED_VERSION"
-               (b/git-count-revs nil)))

--- a/src/exoscale/tools/project/api/git.clj
+++ b/src/exoscale/tools/project/api/git.clj
@@ -1,12 +1,12 @@
 (ns exoscale.tools.project.api.git
-  (:require [clojure.tools.deps.alpha.util.dir :as td]
+  (:require [clojure.string :as str]
+            [clojure.tools.deps.alpha.util.dir :as td]
             [exoscale.tools.project.api.version :as v]
-            [exoscale.tools.project.io :as pio]
-            [clojure.string :as str]))
+            [exoscale.tools.project.io :as pio]))
 
 (defn commit-version
-  [opts]
-  (pio/shell ["git add VERSION"
+  [{:as opts :exoscale.project/keys [version-file]}]
+  (pio/shell [(format "git add %s" version-file)
               "git commit -m \"Version $VERSION\""]
              {:dir td/*the-dir*
               :env {"VERSION" (v/get-version opts)}}))

--- a/src/exoscale/tools/project/api/git.clj
+++ b/src/exoscale/tools/project/api/git.clj
@@ -1,5 +1,7 @@
 (ns exoscale.tools.project.api.git
-  (:require [clojure.string :as str]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.build.api :as b]
             [clojure.tools.deps.alpha.util.dir :as td]
             [exoscale.tools.project.api.version :as v]
             [exoscale.tools.project.io :as pio]))
@@ -31,3 +33,10 @@
                   :fatal? false})
       :out
       str/trim-newline))
+
+(defn git-count-revs
+  [{:as _opts :exoscale.project/keys [version-template-file]
+    :or {version-template-file "VERSION_TEMPLATE"}}]
+  (str/replace (slurp (td/canonicalize (io/file version-template-file)))
+               "GENERATED_VERSION"
+               (b/git-count-revs nil)))

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -82,13 +82,13 @@
    :revision-sha [{:run :exoscale.tools.project.standalone/revision-sha
                    :for-all [:exoscale.project/modules]}]
 
-   :release/single  [{:run :exoscale.tools.project.standalone/version-remove-snapshot}
-                     {:run :exoscale.tools.project.standalone/deploy}
-                     {:run :exoscale.tools.project.standalone/git-commit-version}
-                     {:run :exoscale.tools.project.standalone/git-tag-version}
-                     {:run :exoscale.tools.project.standalone/version-bump-and-snapshot}
-                     {:run :exoscale.tools.project.standalone/git-commit-version}
-                     {:run :exoscale.tools.project.standalone/git-push}]
+   :release/single [{:run :exoscale.tools.project.standalone/version-remove-snapshot}
+                    {:run :exoscale.tools.project.standalone/deploy}
+                    {:run :exoscale.tools.project.standalone/git-commit-version}
+                    {:run :exoscale.tools.project.standalone/git-tag-version}
+                    {:run :exoscale.tools.project.standalone/version-bump-and-snapshot}
+                    {:run :exoscale.tools.project.standalone/git-commit-version}
+                    {:run :exoscale.tools.project.standalone/git-push}]
 
    :release/modules [{:run :exoscale.tools.project.standalone/version-remove-snapshot}
                      {:ref :deploy}
@@ -97,6 +97,12 @@
                      {:run :exoscale.tools.project.standalone/version-bump-and-snapshot}
                      {:run :exoscale.tools.project.standalone/git-commit-version}
                      {:run :exoscale.tools.project.standalone/git-push}]
+
+   :release/git-count-revs
+   [{:run :exoscale.tools.project.standalone/version-git-count-revs}
+    {:run :exoscale.tools.project.standalone/deploy}
+    {:run :exoscale.tools.project.standalone/git-tag-version}
+    {:run :exoscale.tools.project.standalone/git-push}]
 
    :prep-self [{:run :exoscale.tools.project.standalone/prep-self
                 :for-all [:exoscale.project/modules]

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -98,15 +98,13 @@
                      {:run :exoscale.tools.project.standalone/git-commit-version}
                      {:run :exoscale.tools.project.standalone/git-push}]
 
-   :release-git-count-revs/single
-   [{:run :exoscale.tools.project.standalone/version-git-count-revs}
-    {:run :exoscale.tools.project.standalone/deploy}
+   :release+tag/single
+   [{:run :exoscale.tools.project.standalone/deploy}
     {:run :exoscale.tools.project.standalone/git-tag-version}
     {:run :exoscale.tools.project.standalone/git-push}]
 
-   :release-git-count-revs/modules
-   [{:run :exoscale.tools.project.standalone/version-git-count-revs}
-    {:ref :deploy}
+   :release+tag/modules
+   [{:ref :deploy}
     {:run :exoscale.tools.project.standalone/git-tag-version}
     {:run :exoscale.tools.project.standalone/git-push}]
 

--- a/src/exoscale/tools/project/api/tasks.clj
+++ b/src/exoscale/tools/project/api/tasks.clj
@@ -98,9 +98,15 @@
                      {:run :exoscale.tools.project.standalone/git-commit-version}
                      {:run :exoscale.tools.project.standalone/git-push}]
 
-   :release/git-count-revs
+   :release-git-count-revs/single
    [{:run :exoscale.tools.project.standalone/version-git-count-revs}
     {:run :exoscale.tools.project.standalone/deploy}
+    {:run :exoscale.tools.project.standalone/git-tag-version}
+    {:run :exoscale.tools.project.standalone/git-push}]
+
+   :release-git-count-revs/modules
+   [{:run :exoscale.tools.project.standalone/version-git-count-revs}
+    {:ref :deploy}
     {:run :exoscale.tools.project.standalone/git-tag-version}
     {:run :exoscale.tools.project.standalone/git-push}]
 

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -5,17 +5,17 @@
             [clojure.tools.deps.alpha.util.dir :as td]
             [exoscale.deps-version :as version]))
 
-(defn run-version-fn [version-fn]
+(defn run-version-fn [{:as opts :exoscale.project/keys [version-fn]}]
   (when-let [f (requiring-resolve (symbol version-fn))]
-    (f)))
+    (f opts)))
 
 (defn get-version
-  [{:as _opts :exoscale.project/keys [version-file version-fn version]}]
+  [{:as opts :exoscale.project/keys [version-file version-fn version]}]
   (let [version-from-file (some-> version-file version/read-version-file*)]
     (cond
       (string? version) version
       (string? version-from-file) version-from-file
-      (qualified-ident? version-fn) (run-version-fn version-fn))))
+      (qualified-ident? version-fn) (run-version-fn opts))))
 
 (defn remove-snapshot
   [{:as _opts

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -1,8 +1,9 @@
 (ns exoscale.tools.project.api.version
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.build.api :as b]
             [clojure.tools.deps.alpha.util.dir :as td]
-            [exoscale.deps-version :as version]
-            [exoscale.tools.project.api.git :as git]))
+            [exoscale.deps-version :as version]))
 
 (defn get-version
   [{:as _opts :exoscale.project/keys [version-file version]}]
@@ -26,8 +27,15 @@
                            :suffix version-suffix}))
 
 (defn git-count-revs
+  [{:as _opts :exoscale.project/keys [version-template-file]
+    :or {version-template-file "VERSION_TEMPLATE"}}]
+  (str/replace (slurp (td/canonicalize (io/file version-template-file)))
+               "GENERATED_VERSION"
+               (b/git-count-revs nil)))
+
+(defn update-as-git-count-revs
   "Updates VERSION file with clojure core libs like version scheme"
   [{:as opts :exoscale.project/keys [version-file]
     :or {version-file "VERSION"}}]
   (spit (td/canonicalize (io/file version-file))
-        (git/git-count-revs opts)))
+        (git-count-revs opts)))

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -1,5 +1,9 @@
 (ns exoscale.tools.project.api.version
-  (:require [exoscale.deps-version :as version]))
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.build.api :as b]
+            [clojure.tools.deps.alpha.util.dir :as td]
+            [exoscale.deps-version :as version]))
 
 (defn get-version
   [{:as _opts :exoscale.project/keys [version-file version]}]
@@ -21,3 +25,14 @@
   (version/update-version {:file version-file
                            :key version-key
                            :suffix version-suffix}))
+
+(defn git-count-revs-version
+  "Updates VERSION file with clojure core libs like version scheme"
+  [{:as _opts
+    :exoscale.project/keys [version-file version-template-file]
+    :or {version-file "VERSION"
+         version-template-file "VERSION_TEMPLATE"}}]
+  (spit (td/canonicalize (io/file version-file))
+        (str/replace (slurp (td/canonicalize (io/file version-template-file)))
+                     "GENERATED_VERSION"
+                     (b/git-count-revs nil))))

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -34,8 +34,16 @@
                            :suffix version-suffix}))
 
 (defn git-count-revs
+  "To be used via version-fn, returns version as VERSION_TEMPLATE with number of
+  commits on current branch replacing the GENERATED_VERSION placeholder"
   [{:as _opts :exoscale.project/keys [version-template-file]
     :or {version-template-file "VERSION_TEMPLATE"}}]
   (str/replace (slurp (td/canonicalize (io/file version-template-file)))
                "GENERATED_VERSION"
                (b/git-count-revs nil)))
+
+(defn epoch
+  "To be used via version-fn, returns version as VERSION_TEMPLATE with number of
+  seconds since epoch replacing the GENERATED_VERSION placeholder"
+  [_opts]
+  (.getEpochSecond (java.time.Instant/now)))

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -1,9 +1,8 @@
 (ns exoscale.tools.project.api.version
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.tools.build.api :as b]
             [clojure.tools.deps.alpha.util.dir :as td]
-            [exoscale.deps-version :as version]))
+            [exoscale.deps-version :as version]
+            [exoscale.tools.project.api.git :as git]))
 
 (defn get-version
   [{:as _opts :exoscale.project/keys [version-file version]}]
@@ -26,13 +25,9 @@
                            :key version-key
                            :suffix version-suffix}))
 
-(defn git-count-revs-version
+(defn git-count-revs
   "Updates VERSION file with clojure core libs like version scheme"
-  [{:as _opts
-    :exoscale.project/keys [version-file version-template-file]
-    :or {version-file "VERSION"
-         version-template-file "VERSION_TEMPLATE"}}]
+  [{:as opts :exoscale.project/keys [version-file]
+    :or {version-file "VERSION"}}]
   (spit (td/canonicalize (io/file version-file))
-        (str/replace (slurp (td/canonicalize (io/file version-template-file)))
-                     "GENERATED_VERSION"
-                     (b/git-count-revs nil))))
+        (git/git-count-revs opts)))

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -6,7 +6,7 @@
             [exoscale.deps-version :as version]))
 
 (defn run-version-fn [version-fn]
-  (when-let [f (requiring-resolve version-fn)]
+  (when-let [f (requiring-resolve (symbol version-fn))]
     (f)))
 
 (defn get-version

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -5,10 +5,15 @@
             [clojure.tools.deps.alpha.util.dir :as td]
             [exoscale.deps-version :as version]))
 
+(defn run-version-fn [version-fn]
+  (when-let [f (requiring-resolve version-fn)]
+    (f)))
+
 (defn get-version
-  [{:as _opts :exoscale.project/keys [version-file version]}]
+  [{:as _opts :exoscale.project/keys [version-file version-fn version]}]
   (or version
-      (some-> version-file version/read-version-file*)))
+      (some-> version-file version/read-version-file*)
+      (qualified-ident? version-fn) (run-version-fn version-fn)))
 
 (defn remove-snapshot
   [{:as _opts

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -11,9 +11,11 @@
 
 (defn get-version
   [{:as _opts :exoscale.project/keys [version-file version-fn version]}]
-  (or version
-      (some-> version-file version/read-version-file*)
-      (qualified-ident? version-fn) (run-version-fn version-fn)))
+  (let [version-from-file (some-> version-file version/read-version-file*)]
+    (cond
+      (string? version) version
+      (string? version-from-file) version-from-file
+      (qualified-ident? version-fn) (run-version-fn version-fn))))
 
 (defn remove-snapshot
   [{:as _opts

--- a/src/exoscale/tools/project/api/version.clj
+++ b/src/exoscale/tools/project/api/version.clj
@@ -37,10 +37,3 @@
   (str/replace (slurp (td/canonicalize (io/file version-template-file)))
                "GENERATED_VERSION"
                (b/git-count-revs nil)))
-
-(defn update-as-git-count-revs
-  "Updates VERSION file with clojure core libs like version scheme"
-  [{:as opts :exoscale.project/keys [version-file]
-    :or {version-file "VERSION"}}]
-  (spit (td/canonicalize (io/file version-file))
-        (git-count-revs opts)))

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -60,9 +60,11 @@
 
 (defn assoc-version
   [{:as opts :exoscale.project/keys [version-file]}]
-  (cond-> opts
-    (some? version-file)
-    (assoc :exoscale.project/version (version/read-version-file* version-file))))
+
+  (let [v (version/read-version-file* version-file)]
+    (cond-> opts
+      (some? v)
+      (assoc :exoscale.project/version (version/read-version-file* version-file)))))
 
 (defn- assoc-deps-file
   "unless explicit options are given, prepare deps-module configuration"

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -59,11 +59,11 @@
        (catch java.io.FileNotFoundException _fnf)))
 
 (defn assoc-version
-  [{:as opts :exoscale.project/keys [version-file]}]
-  (let [v (version/read-version-file* version-file)]
+  [{:as opts}]
+  (let [v (v/get-version opts)]
     (cond-> opts
       (some? v)
-      (assoc :exoscale.project/version (version/read-version-file* version-file)))))
+      (assoc :exoscale.project/version v))))
 
 (defn- assoc-deps-file
   "unless explicit options are given, prepare deps-module configuration"

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -30,6 +30,8 @@
 
 (s/def :exoscale.project/lib qualified-ident?)
 (s/def :exoscale.project/version string?)
+(s/def :exoscale.project/version-file string?)
+(s/def :exoscale.project/version-fn qualified-ident?)
 (s/def :exoscale.project/target-dir string?)
 (s/def :exoscale.project/class-dir string?)
 (s/def :exoscale.project/javac-opts (s/coll-of string?))
@@ -42,6 +44,7 @@
   (s/keys :opt [:exoscale.project/lib
                 :exoscale.project/version
                 :exoscale.project/version-file
+                :exoscale.project/version-fn
                 :exoscale.project/target-dir
                 :exoscale.project/class-dir
                 :exoscale.project/javac-opts

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -138,6 +138,13 @@
       (assoc :id :release/single)
       (tasks/task opts)))
 
+(defn release-git-count-revs
+  [opts]
+  (-> opts
+      into-opts
+      (assoc :id :release/git-count-revs)
+      (tasks/task opts)))
+
 (def ^{:arglists '([opts])} version-bump-and-snapshot
   (comp v/bump-and-snapshot into-opts))
 
@@ -145,7 +152,7 @@
   (comp v/remove-snapshot into-opts))
 
 (def ^{:arglists '([opts])} version-git-count-revs
-  (comp v/git-count-revs into-opts))
+  (comp v/update-as-git-count-revs into-opts))
 
 (def ^{:arglists '([opts])} git-commit-version
   (comp git/commit-version into-opts))

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -60,7 +60,6 @@
 
 (defn assoc-version
   [{:as opts :exoscale.project/keys [version-file]}]
-
   (let [v (version/read-version-file* version-file)]
     (cond-> opts
       (some? v)

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -142,7 +142,7 @@
   [opts]
   (-> opts
       into-opts
-      (assoc :id :release/git-count-revs)
+      (assoc :id :release-git-count-revs/single)
       (tasks/task opts)))
 
 (def ^{:arglists '([opts])} version-bump-and-snapshot

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -139,11 +139,11 @@
       (assoc :id :release/single)
       (tasks/task opts)))
 
-(defn release-git-count-revs
+(defn release+tag
   [opts]
   (-> opts
       into-opts
-      (assoc :id :release-git-count-revs/single)
+      (assoc :id :release+tag/single)
       (tasks/task opts)))
 
 (def ^{:arglists '([opts])} version-bump-and-snapshot
@@ -151,9 +151,6 @@
 
 (def ^{:arglists '([opts])} version-remove-snapshot
   (comp v/remove-snapshot into-opts))
-
-(def ^{:arglists '([opts])} version-git-count-revs
-  (comp v/update-as-git-count-revs into-opts))
 
 (def ^{:arglists '([opts])} git-commit-version
   (comp git/commit-version into-opts))

--- a/src/exoscale/tools/project/standalone.clj
+++ b/src/exoscale/tools/project/standalone.clj
@@ -1,21 +1,21 @@
 (ns exoscale.tools.project.standalone
   (:refer-clojure :exclude [test])
-  (:require [clojure.edn :as edn]
+  (:require [babashka.fs :as fs]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
-            [clojure.tools.deps.alpha.util.dir :as td]
             [clojure.tools.deps.alpha.specs]
-            [babashka.fs :as fs]
-            [exoscale.deps-version :as version]
+            [clojure.tools.deps.alpha.util.dir :as td]
             [exoscale.deps-modules :as deps-modules]
+            [exoscale.deps-version :as version]
             [exoscale.lingo :as l]
-            [exoscale.tools.project.template :as template]
             [exoscale.tools.project.api :as api]
             [exoscale.tools.project.api.deploy :as deploy]
             [exoscale.tools.project.api.git :as git]
             [exoscale.tools.project.api.jar :as jar]
             [exoscale.tools.project.api.tasks :as tasks]
-            [exoscale.tools.project.api.version :as v]))
+            [exoscale.tools.project.api.version :as v]
+            [exoscale.tools.project.template :as template]))
 
 (def default-opts
   #:exoscale.project{:file "deps.edn"
@@ -143,6 +143,9 @@
 
 (def ^{:arglists '([opts])} version-remove-snapshot
   (comp v/remove-snapshot into-opts))
+
+(def ^{:arglists '([opts])} version-git-count-revs
+  (comp v/git-count-revs into-opts))
 
 (def ^{:arglists '([opts])} git-commit-version
   (comp git/commit-version into-opts))


### PR DESCRIPTION
adds a new standalone+modules task that will create the version from a VERSION_TEMPLATE + a :version-fn key in the deps.edn (similarly to clojure.core projects) and then just tag & push, meaning we get clean master histories without version commits.

The previous versioning scheme didn't change, both can be used independently on separate repositories.

example of usage: https://github.com/exoscale/mania/pull/19/files