### PR TITLE
Init ships fresh tools.project version

### DIFF
--- a/resources/exoscale/project/root/deps.edn
+++ b/resources/exoscale/project/root/deps.edn
@@ -8,7 +8,7 @@
  {:project
   {:ns-default exoscale.tools.project
    :deps {io.github.exoscale/tools.project
-          {:git/sha "29011d6f6245beeabe95c4b2d3eaa1617937b7e0"}}
+          {:git/sha "c3ab9e97d7aa4664fbda71ef5060c7efc451d95c"}}
    :exoscale.deps/inherit :all}
   :test
   {:extra-deps {lambdaisland/kaocha {:exoscale.deps/inherit :all, :mvn/version "1.66.1034"}}
@@ -23,7 +23,7 @@
  {:project
   {:ns-default exoscale.tools.project
    :deps {io.github.exoscale/tools.project
-          {:git/sha "29011d6f6245beeabe95c4b2d3eaa1617937b7e0"}}}
+          {:git/sha "c3ab9e97d7aa4664fbda71ef5060c7efc451d95c"}}}
 
   :test
   {:extra-deps {lambdaisland/kaocha {:exoscale.deps/inherit :all, :mvn/version "1.66.1034"}}


### PR DESCRIPTION
While migrating `partner-api` from Leiningen to `tools.deps`, we realized that `clojure -T:project init …` generates a `deps.edn` with an outdated version of `tools.project` that (in our case) failed to properly dectect `partner-api` as a standalone project (vs "multi-module"). Bumping `tools.project` to a fresh version fixed it right away.